### PR TITLE
권한 처리 구현

### DIFF
--- a/calendar-api/src/main/java/com/example/finalproject/api/config/AuthUserResolver.java
+++ b/calendar-api/src/main/java/com/example/finalproject/api/config/AuthUserResolver.java
@@ -1,0 +1,32 @@
+package com.example.finalproject.api.config;
+
+import com.example.finalproject.api.dto.AuthUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.example.finalproject.api.service.LoginService.LOGIN_SESSION_KEY;
+
+public class AuthUserResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return AuthUser.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        final Long userId = (Long) webRequest.getAttribute(LOGIN_SESSION_KEY, WebRequest.SCOPE_SESSION);
+        if (userId == null) {
+            throw new RuntimeException("bad request. no session");
+        }
+        return AuthUser.of(userId);
+    }
+
+}

--- a/calendar-api/src/main/java/com/example/finalproject/api/config/DevWebConfig.java
+++ b/calendar-api/src/main/java/com/example/finalproject/api/config/DevWebConfig.java
@@ -1,0 +1,19 @@
+package com.example.finalproject.api.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Profile("dev")
+@Configuration
+public class DevWebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new FakeAuthUserResolver());
+    }
+
+}

--- a/calendar-api/src/main/java/com/example/finalproject/api/config/FakeAuthUserResolver.java
+++ b/calendar-api/src/main/java/com/example/finalproject/api/config/FakeAuthUserResolver.java
@@ -1,0 +1,30 @@
+package com.example.finalproject.api.config;
+
+import com.example.finalproject.api.dto.AuthUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class FakeAuthUserResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return AuthUser.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        final String userIdStr = webRequest.getParameter("userId");
+        if (userIdStr == null) {
+            return new AuthUserResolver().resolveArgument(parameter, mavContainer, webRequest, binderFactory);
+        }
+
+        return AuthUser.of(Long.parseLong(userIdStr));
+    }
+
+}

--- a/calendar-api/src/main/java/com/example/finalproject/api/config/WebConfig.java
+++ b/calendar-api/src/main/java/com/example/finalproject/api/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.example.finalproject.api.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Profile("!dev")
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new AuthUserResolver());
+    }
+
+}

--- a/calendar-api/src/main/java/com/example/finalproject/api/controller/ScheduleController.java
+++ b/calendar-api/src/main/java/com/example/finalproject/api/controller/ScheduleController.java
@@ -10,25 +10,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpSession;
-
-import static com.example.finalproject.api.service.LoginService.LOGIN_SESSION_KEY;
-
 @RequiredArgsConstructor
 @RequestMapping("/api/schedules")
 @RestController
 public class ScheduleController {
 
-    private TaskService taskService;
+    private final TaskService taskService;
 
     @PostMapping("/tasks")
     public ResponseEntity<Void> createTask(@RequestBody TaskCreateReq taskCreateReq,
-                                           HttpSession session) {
-        final Long userId = (Long) session.getAttribute(LOGIN_SESSION_KEY);
-        if (userId == null) {
-            throw new RuntimeException("bad request. no session");
-        }
-        taskService.create(taskCreateReq, AuthUser.of(userId));
+                                           AuthUser authUser) {
+        taskService.create(taskCreateReq, authUser);
         return ResponseEntity.ok().build();
     }
 


### PR DESCRIPTION
ScheduleController 개선
--
> ### ScheduleController.java
> - `taskService`를 `final`로 선언
> - `Session` 대신 `AuthUser` 사용

권한 처리 구현
--
> ### AuthUserResolver.java
> - `supportsParameter()` : `AuthUser` 지원 여부
> - `resolveArgument()` : Session key 얻어 `AuthUser` 반환
> 
> ### WebConfig.java
>- 개발 환경이 아닐 때, 실행
>    - `@Profiles("!dev")`
> - `addArgumentResolvers()` : `AuthUserResolver()` 등록

개발 전용 권한 처리 구현
--
> ### FakeAuthUserResolver.java
> - `supportsParameter()` : `AuthUser` 지원 여부
> - `resolverArgument()` : Session key 없어도 `AuthUser` 반환
> 
> ### DevWebConfig.java
> - 개발 환경에서만 실행
>    - `@Profiles("dev")`
> - `addArgumentResolvers()` : `FakeAuthUserResolver()` 등록



closes #17 