### PR TITLE
조회 구현

### DIFF
--- a/calendar-api/src/main/java/com/example/finalproject/api/controller/ScheduleController.java
+++ b/calendar-api/src/main/java/com/example/finalproject/api/controller/ScheduleController.java
@@ -1,24 +1,25 @@
 package com.example.finalproject.api.controller;
 
-import com.example.finalproject.api.dto.AuthUser;
-import com.example.finalproject.api.dto.EventCreateReq;
-import com.example.finalproject.api.dto.NotificationCreateReq;
-import com.example.finalproject.api.dto.TaskCreateReq;
+import com.example.finalproject.api.dto.*;
 import com.example.finalproject.api.service.EventService;
 import com.example.finalproject.api.service.NotificationService;
+import com.example.finalproject.api.service.ScheduleQueryService;
 import com.example.finalproject.api.service.TaskService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/schedules")
 @RestController
 public class ScheduleController {
 
+    private final ScheduleQueryService scheduleQueryService;
     private final TaskService taskService;
     private final EventService eventService;
     private final NotificationService notificationService;
@@ -44,6 +45,31 @@ public class ScheduleController {
     ) {
         notificationService.create(notificationCreateReq, authUser);
         return ResponseEntity.ok().build();
+    }
+
+
+    @GetMapping("/day")
+    public List<ScheduleDto> getScheduleByDay(
+            AuthUser authUser,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        return scheduleQueryService.getScheduleByDay(authUser, date == null ? LocalDate.now() : date);
+    }
+
+    @GetMapping("/week")
+    public List<ScheduleDto> getScheduleByWeek(
+            AuthUser authUser,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startOfWeek) {
+        return scheduleQueryService.getScheduleByWeek(authUser, startOfWeek == null ? LocalDate.now() : startOfWeek);
+    }
+
+    @GetMapping("/month")
+    public List<ScheduleDto> getScheduleByMonth(
+            AuthUser authUser,
+            @RequestParam(required = false)
+            @DateTimeFormat(pattern = "yyyy-MM") String yearMonth) {
+        return scheduleQueryService.getScheduleByMonth(authUser, yearMonth == null ? YearMonth.now() : YearMonth.parse(yearMonth));
     }
 
 }

--- a/calendar-api/src/main/java/com/example/finalproject/api/dto/EventDto.java
+++ b/calendar-api/src/main/java/com/example/finalproject/api/dto/EventDto.java
@@ -1,0 +1,25 @@
+package com.example.finalproject.api.dto;
+
+import com.example.finalproject.core.domain.ScheduleType;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Data
+public class EventDto implements ScheduleDto {
+
+    private final Long scheduleId;
+    private final LocalDateTime startAt;
+    private final LocalDateTime endAt;
+    private final String title;
+    private final String description;
+    private final Long writerId;
+
+    @Override
+    public ScheduleType getScheduleType() {
+        return ScheduleType.EVENT;
+    }
+
+}

--- a/calendar-api/src/main/java/com/example/finalproject/api/dto/NotificationDto.java
+++ b/calendar-api/src/main/java/com/example/finalproject/api/dto/NotificationDto.java
@@ -1,0 +1,23 @@
+package com.example.finalproject.api.dto;
+
+import com.example.finalproject.core.domain.ScheduleType;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Data
+public class NotificationDto implements ScheduleDto {
+
+    private final Long scheduleId;
+    private final LocalDateTime notifyAt;
+    private final String title;
+    private final Long writerId;
+
+    @Override
+    public ScheduleType getScheduleType() {
+        return ScheduleType.NOTIFICATION;
+    }
+    
+}

--- a/calendar-api/src/main/java/com/example/finalproject/api/dto/ScheduleDto.java
+++ b/calendar-api/src/main/java/com/example/finalproject/api/dto/ScheduleDto.java
@@ -1,0 +1,7 @@
+package com.example.finalproject.api.dto;
+
+import com.example.finalproject.core.domain.ScheduleType;
+
+public interface ScheduleDto {
+    ScheduleType getScheduleType();
+}

--- a/calendar-api/src/main/java/com/example/finalproject/api/dto/TaskDto.java
+++ b/calendar-api/src/main/java/com/example/finalproject/api/dto/TaskDto.java
@@ -1,0 +1,24 @@
+package com.example.finalproject.api.dto;
+
+import com.example.finalproject.core.domain.ScheduleType;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Data
+public class TaskDto implements ScheduleDto {
+
+    private final Long scheduleId;
+    private final LocalDateTime taskAt;
+    private final String title;
+    private final String description;
+    private final Long writerId;
+
+    @Override
+    public ScheduleType getScheduleType() {
+        return ScheduleType.TASK;
+    }
+    
+}

--- a/calendar-api/src/main/java/com/example/finalproject/api/service/ScheduleQueryService.java
+++ b/calendar-api/src/main/java/com/example/finalproject/api/service/ScheduleQueryService.java
@@ -1,0 +1,72 @@
+package com.example.finalproject.api.service;
+
+import com.example.finalproject.api.dto.AuthUser;
+import com.example.finalproject.api.dto.ScheduleDto;
+import com.example.finalproject.api.util.DtoConverter;
+import com.example.finalproject.core.domain.entity.Engagement;
+import com.example.finalproject.core.domain.entity.Schedule;
+import com.example.finalproject.core.domain.entity.repository.EngagementRepository;
+import com.example.finalproject.core.domain.entity.repository.ScheduleRepository;
+import com.example.finalproject.core.util.Period;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ScheduleQueryService {
+
+    private final ScheduleRepository scheduleRepository;
+    private final EngagementRepository engagementRepository;
+
+    public List<ScheduleDto> getScheduleByDay(AuthUser authUser, LocalDate date) {
+        return Stream.concat(
+                        scheduleRepository.findAllByWriter_Id(authUser.getId())
+                            .stream()
+                            .filter(schedule -> schedule.isOverlapped(date))
+                            .map(DtoConverter::fromSchedule),
+                        engagementRepository.findAllByAttendee_Id(authUser.getId())
+                                .stream()
+                                .filter(engagement -> engagement.isOverlapped(date))
+                                .map(engagement -> DtoConverter.fromSchedule(engagement.getSchedule())))
+                .collect(Collectors.toList());
+    }
+
+    public List<ScheduleDto> getScheduleByWeek(AuthUser authUser, LocalDate startOfWeek) {
+        final Period period = Period.of(startOfWeek, startOfWeek.plusDays(6));
+
+        return Stream.concat(
+                        scheduleRepository.findAllByWriter_Id(authUser.getId())
+                                .stream()
+                                .filter(schedule -> schedule.isOverlapped(period))
+                                .map(DtoConverter::fromSchedule),
+                        engagementRepository.findAllByAttendee_Id(authUser.getId())
+                                .stream()
+                                .filter(engagement -> engagement.isOverlapped(period))
+                                .map(engagement -> DtoConverter.fromSchedule(engagement.getSchedule())))
+                .collect(Collectors.toList());
+    }
+
+    public List<ScheduleDto> getScheduleByMonth(AuthUser authUser, YearMonth yearMonth) {
+        final Period period = Period.of(yearMonth.atDay(1), yearMonth.atEndOfMonth());
+
+        return Stream.concat(
+                        scheduleRepository.findAllByWriter_Id(authUser.getId())
+                                .stream()
+                                .filter(schedule -> schedule.isOverlapped(period))
+                                .map(DtoConverter::fromSchedule),
+                        engagementRepository.findAllByAttendee_Id(authUser.getId())
+                                .stream()
+                                .filter(engagement -> engagement.isOverlapped(period))
+                                .map(engagement -> DtoConverter.fromSchedule(engagement.getSchedule())))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/calendar-api/src/main/java/com/example/finalproject/api/util/DtoConverter.java
+++ b/calendar-api/src/main/java/com/example/finalproject/api/util/DtoConverter.java
@@ -1,0 +1,42 @@
+package com.example.finalproject.api.util;
+
+import com.example.finalproject.api.dto.EventDto;
+import com.example.finalproject.api.dto.NotificationDto;
+import com.example.finalproject.api.dto.ScheduleDto;
+import com.example.finalproject.api.dto.TaskDto;
+import com.example.finalproject.core.domain.entity.Schedule;
+
+public class DtoConverter {
+
+    public static ScheduleDto fromSchedule(Schedule schedule) {
+        switch (schedule.getScheduleType()) {
+            case TASK:
+                return TaskDto.builder()
+                        .scheduleId(schedule.getId())
+                        .taskAt(schedule.getStartAt())
+                        .title(schedule.getTitle())
+                        .description(schedule.getDescription())
+                        .writerId(schedule.getWriter().getId())
+                        .build();
+            case EVENT:
+                return EventDto.builder()
+                        .scheduleId(schedule.getId())
+                        .startAt(schedule.getStartAt())
+                        .endAt(schedule.getEndAt())
+                        .title(schedule.getTitle())
+                        .description(schedule.getDescription())
+                        .writerId(schedule.getWriter().getId())
+                        .build();
+            case NOTIFICATION:
+                return NotificationDto.builder()
+                        .scheduleId(schedule.getId())
+                        .notifyAt(schedule.getStartAt())
+                        .title(schedule.getTitle())
+                        .writerId(schedule.getWriter().getId())
+                        .build();
+            default:
+                throw new RuntimeException("bad request. not matched schedule type");
+        }
+    }
+
+}

--- a/calendar-core/src/main/java/com/example/finalproject/core/domain/entity/Engagement.java
+++ b/calendar-core/src/main/java/com/example/finalproject/core/domain/entity/Engagement.java
@@ -2,12 +2,14 @@ package com.example.finalproject.core.domain.entity;
 
 import com.example.finalproject.core.domain.Event;
 import com.example.finalproject.core.domain.RequestStatus;
+import com.example.finalproject.core.util.Period;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 
 @Builder
 @AllArgsConstructor
@@ -31,4 +33,13 @@ public class Engagement extends BaseEntity {
     public Event getEvent() {
         return schedule.toEvent();
     }
+
+    public boolean isOverlapped(LocalDate date) {
+        return this.schedule.isOverlapped(date);
+    }
+
+    public boolean isOverlapped(Period period) {
+        return this.schedule.isOverlapped(period);
+    }
+
 }

--- a/calendar-core/src/main/java/com/example/finalproject/core/domain/entity/Schedule.java
+++ b/calendar-core/src/main/java/com/example/finalproject/core/domain/entity/Schedule.java
@@ -4,9 +4,11 @@ import com.example.finalproject.core.domain.Event;
 import com.example.finalproject.core.domain.Notification;
 import com.example.finalproject.core.domain.ScheduleType;
 import com.example.finalproject.core.domain.Task;
+import com.example.finalproject.core.util.Period;
 import lombok.*;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Builder(access = AccessLevel.PRIVATE)
@@ -81,6 +83,14 @@ public class Schedule extends BaseEntity {
 
     public Notification toNotification() {
         return new Notification(this);
+    }
+
+    public boolean isOverlapped(LocalDate date) {
+        return Period.of(getStartAt(), getEndAt()).isOverlapped(date);
+    }
+
+    public boolean isOverlapped(Period period) {
+        return Period.of(getStartAt(), getEndAt()).isOverlapped(period);
     }
 
 }

--- a/calendar-core/src/main/java/com/example/finalproject/core/domain/entity/repository/EngagementRepository.java
+++ b/calendar-core/src/main/java/com/example/finalproject/core/domain/entity/repository/EngagementRepository.java
@@ -3,5 +3,10 @@ package com.example.finalproject.core.domain.entity.repository;
 import com.example.finalproject.core.domain.entity.Engagement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface EngagementRepository extends JpaRepository<Engagement, Long> {
+
+    public List<Engagement> findAllByAttendee_Id(Long userId);
+
 }

--- a/calendar-core/src/main/java/com/example/finalproject/core/domain/entity/repository/ScheduleRepository.java
+++ b/calendar-core/src/main/java/com/example/finalproject/core/domain/entity/repository/ScheduleRepository.java
@@ -3,5 +3,10 @@ package com.example.finalproject.core.domain.entity.repository;
 import com.example.finalproject.core.domain.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    public List<Schedule> findAllByWriter_Id(Long userId);
+
 }

--- a/calendar-core/src/main/java/com/example/finalproject/core/util/Period.java
+++ b/calendar-core/src/main/java/com/example/finalproject/core/util/Period.java
@@ -1,0 +1,49 @@
+package com.example.finalproject.core.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class Period {
+
+    private final LocalDateTime startAt;
+    private final LocalDateTime endAt;
+
+    public Period(LocalDateTime startAt, LocalDateTime endAt) {
+        this.startAt = startAt;
+        if (endAt == null) {
+            this.endAt = startAt;
+        } else {
+            this.endAt = endAt;
+        }
+    }
+
+    public LocalDateTime getStartAt() {
+        return startAt;
+    }
+
+    public LocalDateTime getEndAt() {
+        return endAt;
+    }
+
+    public static Period of(LocalDateTime startAt, LocalDateTime endAt) {
+        return new Period(startAt, endAt);
+    }
+
+    public static Period of(LocalDate startDate, LocalDate endDate) {
+        return new Period(startDate.atStartOfDay(), LocalDateTime.of(endDate, LocalTime.of(23, 59, 59, 999999999)));
+    }
+
+    public boolean isOverlapped(LocalDateTime startAt, LocalDateTime endAt) {
+        return this.startAt.isBefore(endAt) && startAt.isBefore(this.endAt);
+    }
+
+    public boolean isOverlapped(LocalDate date) {
+        return isOverlapped(date.atStartOfDay(), LocalDateTime.of(date, LocalTime.of(23, 59, 59, 999999999)));
+    }
+    
+    public boolean isOverlapped(Period period) {
+        return isOverlapped(period.startAt, period.endAt);
+    }
+
+}


### PR DESCRIPTION
응답 Dto 정의
--
> ### ScheduleDto.java
> - `getScheduleType()` : `ScheduleType` 리턴
> 
> ### TaskDto.java
> - `scheduleId`
> - `taskAt`
> - `title`
> - `description`
> - `writerId`
> - `getScheduleType()` : `TASK` 리턴
> 
> ### EventDto.java
> - `scheduleId`
> - `startAt`
> - `endAt`
> - `title`
> - `description`
> - `writerId`
> - `getScheduleType()` : `EVENT` 리턴
> 
> ### NotificationDto.java
> - `scheduleId`
> - `notifyAt`
> - `title`
> - `wrtierId`
> - `getScheduleType()` : `NOTIFICATION` 리턴

Schedule 조회 구현
--
> ### ScheduleRepository.java
> - `findAllByWriter_Id()` : `writerId`에 해당하는 `Schedule` 리턴
> 
> ### EngagementRepository.java
> - `findAllByAttendee_Id()` : `attendeeId`에 해당하는 `Engagement` 리턴
> 
> ### DtoConverter.java
> - `fromSchedule()` : `Schedule`을 `ScheduleDto`로 변환
> 
> ### Period.java
> - `startAt`
> - `endAt`
> - `of()` : 기간 리턴
> - `isOverlapped()` : 기간 검사
> 
> ### Schedule.java
> - `isOverlapped()` : 기간 검사
> 
> ### Engagement.java
> - `isOverlapped()` : 기간 검사
> 
> ### ScheduleQueryService.java
> - `getScheduleByDay()` : 일별 조회
> - `getScheduleByWeek()` : 주별 조회
> - `getScheduleByMonth()` : 월별 조회
> 
> ### ScheduleController.java
> - `getScheduleByDay()` : 일별 조회
> - `getScheduleByWeek()` : 주별 조회
> - `getScheduleByMonth()` : 월별 조회

closes #23 